### PR TITLE
Update num-complex to v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 dqcsim = "0.2"
 meval = "0.2"
-num-complex = "0.2"
+num-complex = "0.3"
 qasm = "1.0"
 serde_json = "1.0"
 structopt = "0.3"


### PR DESCRIPTION
Required by dqcsim crate.
Solves #38